### PR TITLE
Fix incorrect timeReplacement when timescale is large

### DIFF
--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -269,8 +269,12 @@ shaka.dash.MpdUtils.createTimeline = function(
 
     for (var j = 0; j <= repeat; ++j) {
       var endTime = startTime + d;
-      timeline.push(
-          {start: (startTime / timescale), end: (endTime / timescale)});
+      var item = {
+        start: startTime / timescale,
+        end: endTime / timescale,
+        unscaledStart: startTime
+      };
+      timeline.push(item);
 
       startTime = endTime;
       lastEndTime = endTime;
@@ -398,6 +402,7 @@ shaka.dash.MpdUtils.parseSegmentInfo = function(context, callback) {
     segmentDuration: segmentDuration,
     startNumber: startNumber,
     presentationTimeOffset: pto,
+    unscaledPresentationTimeOffset: Number(presentationTimeOffset),
     timeline: timeline
   };
 };

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -174,6 +174,7 @@ shaka.dash.SegmentTemplate.parseSegmentTemplateInfo_ = function(context) {
     timescale: segmentInfo.timescale,
     startNumber: segmentInfo.startNumber,
     presentationTimeOffset: segmentInfo.presentationTimeOffset,
+    unscaledPresentationTimeOffset: segmentInfo.unscaledPresentationTimeOffset,
     timeline: segmentInfo.timeline,
     mediaTemplate: media,
     indexTemplate: index
@@ -357,6 +358,7 @@ shaka.dash.SegmentTemplate.createFromTimeline_ = function(context, info) {
   var references = [];
   for (var i = 0; i < info.timeline.length; i++) {
     var start = info.timeline[i].start;
+    var unscaledStart = info.timeline[i].unscaledStart;
     var end = info.timeline[i].end;
 
     // Note: i = k - 1, where k indicates the k'th segment listed in the MPD.
@@ -364,9 +366,8 @@ shaka.dash.SegmentTemplate.createFromTimeline_ = function(context, info) {
     var segmentReplacement = i + info.startNumber;
 
     // Consider the presentation time offset in segment uri computation
-    var timeReplacement = (start + info.presentationTimeOffset) *
-        info.timescale;
-
+    var timeReplacement = unscaledStart +
+        info.unscaledPresentationTimeOffset;
     var createUris = (function(
             template, repId, bandwidth, baseUris, segmentId, time) {
           var mediaUri = MpdUtils.fillUriTemplate(


### PR DESCRIPTION
We got a problem with floating point arithmetic when calculating time replacement.

Current code does : 
startTime and presentationTimeOffset are devided : 
`timeline.push(
         {start: (startTime / timescale), end: (endTime / timescale)});`
` var pto = (Number(presentationTimeOffset) / timescale) || 0;`
After that they'll multiply to : 
`timeReplacement = (startTime / timescale + info.presentationTimeOffset) * timescale`
If timescale value is large ( such as 10000000), we can get some problem. 
For example:
`unscaleStartTime = 5405266022342269;`
`startTime = unscaleStartTime/10000000; // = 540526602.234227`
`pto = 27994551;`
`presentationTimeOffset = pto/10000000; // = 2.7994551`
`timeReplacement = (startTime + presentationTimeOffset) * 10000000; // = 5405266050336820`
Actually , It should:
`timeReplacement = uncaledStartTime + pto; // = 5405266050336819`
It produces incorrect segment URLs.

To solve that, we should keep unscaled values (unscaledStartTime, unscaledPresentationTimeOffset) when calculating URLs.

